### PR TITLE
Added Project Mercury

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@
 #### Azure Queues
 * [Azure Functions Hello World with Azure Queues](https://github.com/kedacore/sample-hello-world-azure-functions)
 * [Python jobs with Azure Queue Storage](https://github.com/tomconte/sample-keda-queue-jobs)
+* [Project Mercury - Kubernetes Job orchestration using KEDA](https://github.com/ross-p-smith/Mercury)
 
 #### External Scaler
 * [External Scaler using ActiveMQ Artemis broker](https://github.com/balchua/artemis-ext-scaler)
 
 #### GCP PubSub
 * [Google Cloud PubSub](https://github.com/kedacore/sample-go-gcppubsub)
+* [Project Mercury - Kubernetes Job orchestration using KEDA](https://github.com/ross-p-smith/Mercury)
 
 #### Kafka
 * [Azure Functions and Kafka on Openshift 4](https://github.com/kedacore/keda/wiki/Using-Keda-and-Azure-Functions-on-Openshift-4)

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
 #### Azure Queues
 * [Azure Functions Hello World with Azure Queues](https://github.com/kedacore/sample-hello-world-azure-functions)
 * [Python jobs with Azure Queue Storage](https://github.com/tomconte/sample-keda-queue-jobs)
-* [Project Mercury - Kubernetes Job orchestration using KEDA](https://github.com/ross-p-smith/Mercury)
+* [.Net Job with Azure Storage Queue](https://github.com/ross-p-smith/Mercury)
 
 #### External Scaler
 * [External Scaler using ActiveMQ Artemis broker](https://github.com/balchua/artemis-ext-scaler)
 
 #### GCP PubSub
 * [Google Cloud PubSub](https://github.com/kedacore/sample-go-gcppubsub)
-* [Project Mercury - Kubernetes Job orchestration using KEDA](https://github.com/ross-p-smith/Mercury)
+* [.Net Job with Google Cloud PubSub](https://github.com/ross-p-smith/Mercury)
 
 #### Kafka
 * [Azure Functions and Kafka on Openshift 4](https://github.com/kedacore/keda/wiki/Using-Keda-and-Azure-Functions-on-Openshift-4)


### PR DESCRIPTION
Project Mercury is a working template of how you could create jobs in Kubernetes based on queue length in a cloud agnostic manner. The current implementation supports Azure and GCP. The solution provides all of teh necessary scripts to pull this into a full CI/CD pipeline