### PR TITLE
Added link for sample to Kafka trigger scalar with Event Hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 #### Azure EventHub
 * [Azure Functions NodeJS function with EventHub](https://github.com/kedacore/sample-javascript-eventhub-azure-function)
+* [Java Application processing messages from Kafka head on Event Hubs](https://github.com/rasavant-ms/sample-java-kafka-event-hub-scalar)
 
 #### Azure Service Bus Queue
 * [.NET Core 3.0 Worker with Azure Service Bus Queue](https://github.com/kedacore/sample-dotnet-worker-servicebus-queue) *(Owner: @tomkerkhove)*


### PR DESCRIPTION
This supplements the changes made to the Kafka Trigger scalar in KEDA to work with Event Hubs Kafka head.