### PR TITLE
Add Twitch chat messages external scaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 
 #### External Scaler
 * [External Scaler using ActiveMQ Artemis broker](https://github.com/balchua/artemis-ext-scaler)
+* [External Scaler that scales workloads based on Twitch chat messages, built on .NET Core](https://github.com/eashi/kaboom-keda-scaler/)
 
 #### GCP PubSub
 * [Google Cloud PubSub](https://github.com/kedacore/sample-go-gcppubsub)


### PR DESCRIPTION
This is a sample External Scaler built on .NET Core. Built live on Twitch.

The goal of this sample is to be very simple, so that there is no complexity of a real problem to get in the way of learning.

When someone in the Twitch chat sends the word "kaboom", the deployment will scale to the count of the letter 'o' in "kaboom" e.g. "kaboooom" will scale to 5 instances. On the other hand, if the chat message was "fssst", it will scale down to the number of 's' in "fssst".
Or the difference between the two.

Here is a [3 minutes video](https://www.twitch.tv/videos/621363240) of when the deployment in my local cluster scaled out based on the chat message.

I tried to leave code comments as a guide to anyone who is reading the code. Would love to hear any feedback regardless if this is pulled in or not.
