### PR TITLE
Provide IBM MQ scaler sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 * [.Net Job with Google Cloud PubSub](https://github.com/ross-p-smith/Mercury)
 
 #### IBM MQ
-* [IBM MQ using Go](https://github.com/ibm-messaging/mq-dev-patterns/tree/master/Go-K8s)
+* [IBM MQ using a Go consumer & producer](https://github.com/ibm-messaging/mq-dev-patterns/tree/master/Go-K8s)
 
 #### Kafka
 * [Autoscaling Dapr service based on queue depth](https://github.com/mchmarny/dapr-demos/tree/master/autoscaling-on-queue)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 ## Samples 
 (If you have any samples to share; please submit a PR to add it to the list!)
 
-#### Azure EventHub
+#### Azure Event Hubs
 * [Azure Functions NodeJS function with EventHub](https://github.com/kedacore/sample-javascript-eventhub-azure-function)
 * [Java Application processing messages from Kafka head on Event Hubs](https://github.com/rasavant-ms/sample-java-kafka-event-hub-scalar)
 
 #### Azure Service Bus Queue
 * [.NET Core 3.0 Worker with Azure Service Bus Queue](https://github.com/kedacore/sample-dotnet-worker-servicebus-queue) *(Owner: @tomkerkhove)*
 
-#### Azure ServiceBus Topic
+#### Azure Service Bus Topic
 * [Service Bus Topic consumed by .NET Core 3 console app](https://github.com/felipecruz91/sample-dotnet-consumer-servicebus-topic)
 * [Crowd Analytics Platform: Guided workshop that leverages Service Bus Topics + Azure Functions](https://github.com/mohamedsaif/IntelligentExperiences.OnContainers)
 
-#### Azure Queues
+#### Azure Storage Queues
 * [Azure Functions Hello World with Azure Queues](https://github.com/kedacore/sample-hello-world-azure-functions)
 * [Python jobs with Azure Queue Storage](https://github.com/tomconte/sample-keda-queue-jobs)
 * [.Net Job with Azure Storage Queue](https://github.com/ross-p-smith/Mercury)
@@ -26,6 +26,7 @@
 * [.Net Job with Google Cloud PubSub](https://github.com/ross-p-smith/Mercury)
 
 #### Kafka
+* [Autoscaling Dapr service based on queue depth](https://github.com/mchmarny/dapr-demos/tree/master/autoscaling-on-queue)
 * [Azure Functions and Kafka on Openshift 4](https://github.com/kedacore/sample-azure-functions-on-ocp4)
 * [Azure Functions processing tweets from Kafka](https://github.com/kedacore/sample-typescript-kafka-azure-function)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
 * [Google Cloud PubSub](https://github.com/kedacore/sample-go-gcppubsub)
 * [.Net Job with Google Cloud PubSub](https://github.com/ross-p-smith/Mercury)
 
+#### IBM MQ
+* [IBM MQ using Go](https://github.com/ibm-messaging/mq-dev-patterns/tree/master/Go-K8s)
+
 #### Kafka
 * [Autoscaling Dapr service based on queue depth](https://github.com/mchmarny/dapr-demos/tree/master/autoscaling-on-queue)
 * [Azure Functions and Kafka on Openshift 4](https://github.com/kedacore/sample-azure-functions-on-ocp4)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 
 #### Nats Streaming
 * [Nats Streaming with Go](https://github.com/balchua/gonuts)
+* [Nats streaming with Keda and Virtual Kubelet](https://github.com/infracloudio/keda-vk-aci)
 
 #### MySQL
 * [Using MySQL queries and KEDA](https://github.com/nuclearpinguin/keda-example#mysql-example)


### PR DESCRIPTION
As in [issue #1253](https://github.com/kedacore/keda/issues/1253), this PR adds the IBM MQ sample application to the list of KEDA samples.  