### PR TITLE
added prometheus sample for keda2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@
 
 - [Nats Streaming with Go](https://github.com/balchua/gonuts)
 
+#### Prometheus
+
+- [Autoscale Kubernetes Pods based on ingress request — prometheus, keda, and k6](https://blog.cloudacode.com/how-to-autoscale-kubernetes-pods-based-on-ingress-request-prometheus-keda-and-k6-84ae4250a9f3)
+
 #### Redis
 
 - [Using Redis scaler](https://github.com/nuclearpinguin/keda-example#redis-example)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 #### Prometheus
 
-- [Autoscale Kubernetes Pods based on ingress request — prometheus, keda, and k6](https://blog.cloudacode.com/how-to-autoscale-kubernetes-pods-based-on-ingress-request-prometheus-keda-and-k6-84ae4250a9f3)
+- [Autoscale Kubernetes pods based on ingress request — Prometheus, KEDA, and K6](https://blog.cloudacode.com/how-to-autoscale-kubernetes-pods-based-on-ingress-request-prometheus-keda-and-k6-84ae4250a9f3)
 
 #### Redis
 


### PR DESCRIPTION
added prometheus sample for KEDA2
[Autoscale Kubernetes pods based on ingress request — Prometheus, KEDA, and K6](https://blog.cloudacode.com/how-to-autoscale-kubernetes-pods-based-on-ingress-request-prometheus-keda-and-k6-84ae4250a9f3)

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #
